### PR TITLE
Rewrite PowerShell Scripts

### DIFF
--- a/script/run-debug.ps1
+++ b/script/run-debug.ps1
@@ -1,4 +1,4 @@
-# run-debug.ps1  Copyright (C) 2023  Haizhao Dai
+# run-debug.ps1  Copyright (C) 2023  Haizhao Dai and Zhonghan Zhang
 #
 # This program comes with ABSOLUTELY NO WARRANTY.
 # This is free software, and you are welcome to redistribute it
@@ -8,11 +8,58 @@ function info() {
     Write-Host "$args" -ForegroundColor Blue
 }
 
+function error() {
+    Write-Host "[ERROR] $args" -ForegroundColor Red
+}
+
+function handle_error($command) {
+    if(-not $?) {
+      error "Error occurs when executing $($command)"
+      error "Exit."
+      exit 1;
+    }
+}
+
+function make_dir($path) {
+  if(-not (Test-Path $path)) {
+    mkdir $path | Out-Null
+  }
+}
+
+
+$current_directory_is_script = (pwd).Path -match 'script$'
+if(-not $current_directory_is_script) {
+  error "Working directory error"
+  info "Please switch to 'script' directory and run this srcipt."
+  info "Try to use command 'cd ./script/'"
+  info "Exit"
+  exit 1;
+}
+
+
+$bin_dir_name = "../windows-build/Debug"
+make_dir $bin_dir_name
+
+
+$result_dir_name = "../result"
+make_dir $result_dir_name
+
+$include_dir_name = "../include"
+make_dir $include_dir_name
+
+$build_executable_name = "CS100-Ray-Tracing.exe"
 info "[script] Compiling..."
-gcc (Get-ChildItem ..\src\*.c) -o "..\windows-build\Debug\CS100-Ray-Tracing" -I "..\include" -g -std=c17 -Wall -Wextra -Wpedantic -Werror -lm
+gcc (Get-ChildItem ..\src\*.c) -o "$($bin_dir_name)/$($build_executable_name)" -I $include_dir_name -g -std=c17 -Wall -Wextra -Wpedantic -Werror -lm
+handle_error "gcc"
+
 
 info "[script] Generating image.ppm..."
-.\"..\windows-build\Debug\CS100-Ray-Tracing.exe" | out-file "..\result\image.ppm" -encoding utf8
+&"$($bin_dir_name)/$($build_executable_name)" | Out-File -FilePath "$($result_dir_name)\image.ppm" -Encoding utf8
+handle_error "$($bin_dir_name)/$($build_executable_name)" 
+
 
 info "[script] Converting image.ppm to image.png..."
-python "ppm-to-png.py" "..\result\image.ppm"
+python ".\ppm-to-png.py" "$($result_dir_name)\image.ppm"
+handle_error "python"
+
+info "Success! Image built at $($result_dir_name)\image.png"

--- a/script/run-debug.ps1
+++ b/script/run-debug.ps1
@@ -14,52 +14,41 @@ function error() {
 
 function handle_error($command) {
     if(-not $?) {
-      error "Error occurs when executing $($command)"
-      error "Exit."
-      exit 1;
+        error "Error occurs when executing $($command)"
+        exit 1;
     }
 }
 
 function make_dir($path) {
-  if(-not (Test-Path $path)) {
-    mkdir $path | Out-Null
-  }
+    if(-not (Test-Path $path)) {
+        mkdir $path | Out-Null
+    }
 }
 
 
 $current_directory_is_script = (pwd).Path -match 'script$'
 if(-not $current_directory_is_script) {
-  error "Working directory error"
-  info "Please switch to 'script' directory and run this srcipt."
-  info "Try to use command 'cd ./script/'"
-  info "Exit"
-  exit 1;
+    error "Working directory error."
+    info "Please switch to 'script' directory and run this srcipt."
+    info "Try to use command 'cd ./script/'."
+    exit 1;
 }
-
 
 $bin_dir_name = "../windows-build/Debug"
 make_dir $bin_dir_name
 
-
 $result_dir_name = "../result"
 make_dir $result_dir_name
-
-$include_dir_name = "../include"
-make_dir $include_dir_name
 
 $build_executable_name = "CS100-Ray-Tracing.exe"
 info "[script] Compiling..."
 gcc (Get-ChildItem ..\src\*.c) -o "$($bin_dir_name)/$($build_executable_name)" -I $include_dir_name -g -std=c17 -Wall -Wextra -Wpedantic -Werror -lm
 handle_error "gcc"
 
-
 info "[script] Generating image.ppm..."
 &"$($bin_dir_name)/$($build_executable_name)" | Out-File -FilePath "$($result_dir_name)\image.ppm" -Encoding utf8
-handle_error "$($bin_dir_name)/$($build_executable_name)" 
-
+handle_error "$($bin_dir_name)/$($build_executable_name)"
 
 info "[script] Converting image.ppm to image.png..."
 python ".\ppm-to-png.py" "$($result_dir_name)\image.ppm"
 handle_error "python"
-
-info "Success! Image built at $($result_dir_name)\image.png"

--- a/script/run-release.ps1
+++ b/script/run-release.ps1
@@ -1,4 +1,4 @@
-# run-release.ps1  Copyright (C) 2023  Haizhao Dai
+# run-release.ps1  Copyright (C) 2023  Haizhao Dai and Zhonghan Zhang
 #
 # This program comes with ABSOLUTELY NO WARRANTY.
 # This is free software, and you are welcome to redistribute it
@@ -8,11 +8,57 @@ function info() {
     Write-Host "$args" -ForegroundColor Blue
 }
 
+function error() {
+    Write-Host "[ERROR] $args" -ForegroundColor Red
+}
+
+function handle_error($command) {
+    if(-not $?) {
+      error "Error occurs when executing $($command)"
+      error "Exit."
+      exit 1;
+    }
+}
+
+function make_dir($path) {
+  if(-not (Test-Path $path)) {
+    mkdir $path | Out-Null
+  }
+}
+
+
+$current_directory_is_script = (pwd).Path -match 'script$'
+if(-not $current_directory_is_script) {
+  error "Working directory error"
+  info "Please switch to 'script' directory and run this srcipt."
+  info "Try to use command 'cd ./script/'"
+  info "Exit"
+  exit 1;
+}
+
+$bin_dir_name = "../windows-build/Release"
+make_dir $bin_dir_name
+
+
+$result_dir_name = "../result"
+make_dir $result_dir_name
+
+$include_dir_name = "../include"
+make_dir $include_dir_name
+
+$build_executable_name = "CS100-Ray-Tracing.exe"
 info "[script] Compiling..."
-gcc (Get-ChildItem ..\src\*.c) -o "..\windows-build\Release\CS100-Ray-Tracing" -I "..\include" -O3 -std=c17 -Wall -Wextra -Wpedantic -Werror -lm
+gcc (Get-ChildItem ..\src\*.c) -o "$($bin_dir_name)/$($build_executable_name)" -I $include_dir_name -O3 -std=c17 -Wall -Wextra -Wpedantic -Werror -lm
+handle_error "gcc"
+
 
 info "[script] Generating image.ppm..."
-.\"..\windows-build\Release\CS100-Ray-Tracing.exe" | out-file "..\result\image.ppm" -encoding utf8
+&"$($bin_dir_name)/$($build_executable_name)" | Out-File -FilePath "$($result_dir_name)\image.ppm" -Encoding utf8
+handle_error "$($bin_dir_name)/$($build_executable_name)" 
+
 
 info "[script] Converting image.ppm to image.png..."
-python "ppm-to-png.py" "..\result\image.ppm"
+python ".\ppm-to-png.py" "$($result_dir_name)\image.ppm"
+handle_error "python"
+
+info "Success! Image built at $($result_dir_name)\image.png"

--- a/script/run-release.ps1
+++ b/script/run-release.ps1
@@ -14,51 +14,41 @@ function error() {
 
 function handle_error($command) {
     if(-not $?) {
-      error "Error occurs when executing $($command)"
-      error "Exit."
-      exit 1;
+        error "Error occurs when executing $($command)"
+        exit 1;
     }
 }
 
 function make_dir($path) {
-  if(-not (Test-Path $path)) {
-    mkdir $path | Out-Null
-  }
+    if(-not (Test-Path $path)) {
+        mkdir $path | Out-Null
+    }
 }
 
 
 $current_directory_is_script = (pwd).Path -match 'script$'
 if(-not $current_directory_is_script) {
-  error "Working directory error"
-  info "Please switch to 'script' directory and run this srcipt."
-  info "Try to use command 'cd ./script/'"
-  info "Exit"
-  exit 1;
+    error "Working directory error."
+    info "Please switch to 'script' directory and run this srcipt."
+    info "Try to use command 'cd ./script/'."
+    exit 1;
 }
 
 $bin_dir_name = "../windows-build/Release"
 make_dir $bin_dir_name
 
-
 $result_dir_name = "../result"
 make_dir $result_dir_name
 
-$include_dir_name = "../include"
-make_dir $include_dir_name
-
 $build_executable_name = "CS100-Ray-Tracing.exe"
 info "[script] Compiling..."
-gcc (Get-ChildItem ..\src\*.c) -o "$($bin_dir_name)/$($build_executable_name)" -I $include_dir_name -O3 -std=c17 -Wall -Wextra -Wpedantic -Werror -lm
+gcc (Get-ChildItem ..\src\*.c) -o "$($bin_dir_name)/$($build_executable_name)" -I $include_dir_name -g -std=c17 -Wall -Wextra -Wpedantic -Werror -lm
 handle_error "gcc"
-
 
 info "[script] Generating image.ppm..."
 &"$($bin_dir_name)/$($build_executable_name)" | Out-File -FilePath "$($result_dir_name)\image.ppm" -Encoding utf8
-handle_error "$($bin_dir_name)/$($build_executable_name)" 
-
+handle_error "$($bin_dir_name)/$($build_executable_name)"
 
 info "[script] Converting image.ppm to image.png..."
 python ".\ppm-to-png.py" "$($result_dir_name)\image.ppm"
 handle_error "python"
-
-info "Success! Image built at $($result_dir_name)\image.png"


### PR DESCRIPTION
[feature] Automatically create `include/`, `build/` and `result/` directory (to align with the behavior of the bash script).

[feature] Exit this script when error occurs (to align with the behavior of the bash script, too).

[feature] Check current location is at `script/` before executing the scripts to avoid problems about file paths.